### PR TITLE
Extracted IgCacheFactoryBase from IgCacheFactory.

### DIFF
--- a/src/main/java/io/ebean/ignite/IgCacheFactoryBase.java
+++ b/src/main/java/io/ebean/ignite/IgCacheFactoryBase.java
@@ -1,0 +1,199 @@
+package io.ebean.ignite;
+
+import io.ebean.BackgroundExecutor;
+import io.ebean.cache.*;
+import io.ebeaninternal.server.cache.DefaultServerCacheConfig;
+import io.ebeaninternal.server.cache.DefaultServerQueryCache;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteMessaging;
+import org.apache.ignite.lang.IgniteBiPredicate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public abstract class IgCacheFactoryBase implements ServerCacheFactory {
+
+    private static final Logger queryLogger = LoggerFactory.getLogger("org.avaje.ebean.cache.QUERY");
+
+    protected static final Logger logger = LoggerFactory.getLogger("org.avaje.ebean.cache.CACHE");
+
+    private static final Logger tableModLogger = LoggerFactory.getLogger("io.ebean.cache.TABLEMODS");
+
+    private static final String QC_INVALIDATE = "L2QueryCacheInvalidate";
+
+    private static final String TABLE_MOD = "L2TableMod";
+
+    private final ConcurrentHashMap<String, IgQueryCache> queryCaches;
+
+    private final BackgroundExecutor executor;
+
+    protected final Ignite ignite;
+
+    private final IgniteMessaging messaging;
+
+    private ServerCacheNotify listener;
+
+
+    protected IgCacheFactoryBase(BackgroundExecutor executor, Ignite ignite) {
+        this.executor = executor;
+        this.queryCaches = new ConcurrentHashMap<>();
+        this.ignite = ignite;
+        messaging = ignite.message(ignite.cluster().forRemotes());
+        messaging.localListen(QC_INVALIDATE, new QueryCacheInvalidateListener());
+        messaging.localListen(TABLE_MOD, new TableModListener());
+    }
+
+    @Override
+    public ServerCacheNotify createCacheNotify(ServerCacheNotify listener) {
+        this.listener = listener;
+        return new IgServerCacheNotify();
+    }
+
+    private class QueryCacheInvalidateListener implements IgniteBiPredicate<UUID, String> {
+        @Override
+        public boolean apply(UUID uuid, String key) {
+            queryCacheInvalidate(key);
+            return true;
+        }
+    }
+
+    private class TableModListener implements IgniteBiPredicate<UUID, String> {
+        @Override
+        public boolean apply(UUID uuid, String rawMessage) {
+            processTableNotify(rawMessage);
+            return true;
+        }
+    }
+
+    @Override
+    public ServerCache createCache(ServerCacheConfig config) {
+
+        if (config.isQueryCache()) {
+            return createQueryCache(config);
+        }
+        return new IgCache(createNormalCache(config), config.getTenantProvider());
+    }
+
+    protected abstract <K,V> IgniteCache<K,V>  createNormalCache(ServerCacheConfig config);
+
+    /**
+     * Return the full cache name (JMX safe name).
+     */
+    protected static String fullName(ServerCacheType type, String key) {
+        return type.name() + '-' + key;
+    }
+
+    /**
+     * Create a local/near query cache.
+     */
+    private ServerCache createQueryCache(ServerCacheConfig config) {
+        synchronized (this) {
+            IgQueryCache cache = queryCaches.get(config.getCacheKey());
+            if (cache == null) {
+                logger.debug("create query cache [{}]", config.getCacheKey());
+                cache = new IgQueryCache(new DefaultServerCacheConfig(config));
+                cache.periodicTrim(executor);
+                queryCaches.put(config.getCacheKey(), cache);
+            }
+            return cache;
+        }
+    }
+
+    /**
+     * Local only cache implementation with no serialisation requirements.
+     * <p>
+     * Uses Ignite topic to invalidate across the cluster.
+     * </p>
+     */
+    private class IgQueryCache extends DefaultServerQueryCache {
+
+        IgQueryCache(DefaultServerCacheConfig config) {
+            super(config);
+        }
+
+        @Override
+        public void clear() {
+            super.clear();
+            sendQueryCacheInvalidation(name);
+        }
+
+        /**
+         * Process the invalidation message coming from the cluster.
+         */
+        private void invalidate() {
+            queryLogger.debug("   CLEAR {}(*) - cluster invalidate", name);
+            super.clear();
+        }
+    }
+
+    /**
+     * Send the invalidation message to all members of the cluster.
+     */
+    private void sendQueryCacheInvalidation(String key) {
+        messaging.send(QC_INVALIDATE, key);
+    }
+
+    /**
+     * Clear the query cache if we have it.
+     */
+    private void queryCacheInvalidate(String key) {
+        IgQueryCache queryCache = queryCaches.get(key);
+        if (queryCache != null) {
+            queryCache.invalidate();
+        }
+    }
+
+    /**
+     * Process a remote dependent table modify event.
+     */
+    private void processTableNotify(String rawMessage) {
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("processTableNotify {}", rawMessage);
+        }
+
+        String[] split = rawMessage.split(",");
+        Set<String> tables = new HashSet<>(Arrays.asList(split));
+        listener.notify(new ServerCacheNotification(tables));
+    }
+
+    /**
+     * Send the invalidation message to all members of the cluster.
+     */
+    private void sendTableMod(String key) {
+        messaging.send(TABLE_MOD, key);
+    }
+
+    /**
+     * Send the table modifications via Hazelcast topic.
+     */
+    class IgServerCacheNotify implements ServerCacheNotify {
+
+
+        @Override
+        public void notify(ServerCacheNotification tableModifications) {
+
+            Set<String> dependentTables = tableModifications.getDependentTables();
+            if (dependentTables != null && !dependentTables.isEmpty()) {
+
+                StringBuilder msg = new StringBuilder(50);
+                for (String table : dependentTables) {
+                    msg.append(table).append(",");
+                }
+
+                String formattedMsg = msg.toString();
+                if (tableModLogger.isDebugEnabled()) {
+                    tableModLogger.debug("Publish TableMods - {}", formattedMsg);
+                }
+                sendTableMod(formattedMsg);
+            }
+        }
+    }
+
+}

--- a/src/main/java/io/ebean/ignite/IgCachePlugin.java
+++ b/src/main/java/io/ebean/ignite/IgCachePlugin.java
@@ -15,6 +15,6 @@ public class IgCachePlugin implements ServerCachePlugin {
    */
   @Override
   public ServerCacheFactory create(ServerConfig config, BackgroundExecutor executor) {
-    return new IgCacheFactory(config, executor);
+    return IgCacheFactory.create(config, executor);
   }
 }


### PR DESCRIPTION
I have extracted code from IgCacheFactory to IgCacheFactoryBase.
Now IgCacheFactoryBase does all the Ignite work and IgCacheFactory adds XML configuration.

I have done this, because now I'm able to use IgCacheFactoryBase with:
- my custom Ignite instance which is created in other part of code and used in few other places,
- generate caches for tables with code (override abstract method).

Example usage:
```java
		DatabaseConfig conf = new DatabaseConfig();
		conf.setName("Ebean");
		conf.setServerCachePlugin(new ServerCachePlugin() {
			@Override
			public ServerCacheFactory create(ServerConfig config, BackgroundExecutor executor) {
				return new IgCacheFactoryBase(executor, ignite) {
					protected <K,V> IgniteCache<K,V> createNormalCache(ServerCacheConfig config) {
						String fullName = fullName(config.getType(), config.getCacheKey());
						/// Create ignite cache
						return cache;
					}
				};
			}
		});

```
So far, to achieve this I had to copy IgCache, IgCacheFactory, IgCachePlugin from this repository into my code and remove XML configuration code.
